### PR TITLE
Refresh README for dark mode and revive blog post workflow

### DIFF
--- a/.github/workflows/blog-post-workflow.yml
+++ b/.github/workflows/blog-post-workflow.yml
@@ -1,14 +1,19 @@
 name: Latest blog post workflow
 on:
-  schedule: # Run workflow automatically
+  schedule:
     - cron: "0 * * * *" # Runs every hour, on the hour
-  workflow_dispatch: # Run workflow manually (without waiting for the cron to be called), through the Github Actions Workflow page directly
+  workflow_dispatch: # Run workflow manually from the Actions tab
+
+permissions:
+  contents: write
+
 jobs:
   update-readme-with-blog:
     name: Update this repo's README with latest blog posts
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: gautamkrishnar/blog-post-workflow@master
+      - uses: actions/checkout@v4
+      - uses: gautamkrishnar/blog-post-workflow@v1
         with:
-          feed_list: "https://medium.com/feed/@gantlaborde"
+          max_post_count: 6
+          feed_list: "https://medium.com/feed/@gantlaborde,https://shift.infinite.red/feed"

--- a/README.md
+++ b/README.md
@@ -1,68 +1,87 @@
-<table width="100%">
-<tr>
-  <td><img src="https://gantlaborde.com/wp-content/uploads/2022/11/React-Advanced-London-2022-559x372.jpg" align="left" width="300" /></td>
-  <td>
+<div align="center">
 
-<h1 align="center">Hi 👋, I'm Gant</h1>
-<h3 align="center">a mad scientist in training.</h3>
+<img src="https://gantlaborde.com/wp-content/uploads/2022/11/React-Advanced-London-2022-559x372.jpg" width="420" alt="Gant speaking at React Advanced London 2022" />
 
-<p align="center"> <img src="https://komarev.com/ghpvc/?username=gantman" alt="gantman" /> </p>
+# Hi 👋, I'm Gant
 
-- 🔭 &nbsp; I’m currently working on **cool things with TensorFlow.js** and **React Native**.  <a href="https://twitter.com/GantLaborde" target="_blank">Follow me on Twitter!<a/>
+### a mad scientist in training.
 
-- 👨‍💻 &nbsp; All of my public speaking is available at [https://gantlaborde.com/](https://gantlaborde.com/)
+[![Profile Views](https://komarev.com/ghpvc/?username=gantman&style=flat-square&color=blueviolet)](https://github.com/gantman)
+[![Website](https://img.shields.io/badge/Website-gantlaborde.com-1f6feb?style=flat-square&logo=safari&logoColor=white)](https://gantlaborde.com/)
+[![Twitter Follow](https://img.shields.io/twitter/follow/GantLaborde?style=flat-square&logo=x&logoColor=white&color=000000)](https://twitter.com/GantLaborde)
 
+</div>
+
+- 🔭 &nbsp; Currently working on **cool things with TensorFlow.js** and **React Native**
+- 👨‍💻 &nbsp; Public speaking talks & resources at **[gantlaborde.com](https://gantlaborde.com/)**
 - 💬 &nbsp; Ask me about **React, React Native, AI, ML, and TensorFlow.js**
+- 🏢 &nbsp; CIO at **[Infinite Red](https://infinite.red/)** — based in **New Orleans**
 
-</td>
-  </tr>
-</table>
+---
 
+### 🤝 &nbsp; Affiliations
 
-<table style="table-layout: fixed;">
-  <tr>
-      <th width="50%">
-        My Affiliate Groups
-        </th>
-              <th>
-            Fav Tech
-        </th>
-    </tr>
-  <tr>
-    <td>
-<ul>
-  <li> Google GDE (Web/ML)</li>
-  <li> AWS Community Builders</li>
-  <li> Cloudinary MDE</li>
-  <li> Oracle Groundbreaker Ambassador</li>
-  <li> Distinguished Toastmaster</li>
-</ul>
-</td>
-    <td>
-<p align="left"> <a href="https://aws.amazon.com/amplify/" target="_blank"> <img src="https://docs.amplify.aws/assets/logo-dark.svg" alt="amplify" width="40" height="40"/> </a> <a href="https://developer.android.com" target="_blank"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/android/android-original-wordmark.svg" alt="android" width="40" height="40"/> </a> <a href="https://www.arduino.cc/" target="_blank"> <img src="https://cdn.worldvectorlogo.com/logos/arduino-1.svg" alt="arduino" width="40" height="40"/> </a> <a href="https://aws.amazon.com" target="_blank"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/amazonwebservices/amazonwebservices-original-wordmark.svg" alt="aws" width="40" height="40"/> </a> <a href="https://www.w3schools.com/css/" target="_blank"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/css3/css3-original-wordmark.svg" alt="css3" width="40" height="40"/> </a> <a href="https://cloud.google.com" target="_blank"> <img src="https://www.vectorlogo.zone/logos/google_cloud/google_cloud-icon.svg" alt="gcp" width="40" height="40"/> </a> <a href="https://git-scm.com/" target="_blank"> <img src="https://www.vectorlogo.zone/logos/git-scm/git-scm-icon.svg" alt="git" width="40" height="40"/> </a> <a href="https://www.w3.org/html/" target="_blank"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/html5/html5-original-wordmark.svg" alt="html5" width="40" height="40"/> </a> <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript" target="_blank"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/javascript/javascript-original.svg" alt="javascript" width="40" height="40"/> </a> <a href="https://jestjs.io" target="_blank"> <img src="https://www.vectorlogo.zone/logos/jestjsio/jestjsio-icon.svg" alt="jest" width="40" height="40"/> </a> <a href="https://www.linux.org/" target="_blank"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/linux/linux-original.svg" alt="linux" width="40" height="40"/> </a> <a href="https://www.photoshop.com/en" target="_blank"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/photoshop/photoshop-line.svg" alt="photoshop" width="40" height="40"/> </a> <a href="https://postman.com" target="_blank"> <img src="https://www.vectorlogo.zone/logos/getpostman/getpostman-icon.svg" alt="postman" width="40" height="40"/> </a> <a href="https://www.python.org" target="_blank"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/python/python-original.svg" alt="python" width="40" height="40"/> </a> <a href="https://reactjs.org/" target="_blank"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/react/react-original-wordmark.svg" alt="react" width="40" height="40"/> </a> <a href="https://reactnative.dev/" target="_blank"> <img src="https://reactnative.dev/img/header_logo.svg" alt="reactnative" width="40" height="40"/> </a> <a href="https://www.ruby-lang.org/en/" target="_blank"> <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/ruby/ruby-original.svg" alt="ruby" width="40" height="40"/> </a> <a href="https://www.tensorflow.org" target="_blank"> <img src="https://www.vectorlogo.zone/logos/tensorflow/tensorflow-icon.svg" alt="tensorflow" width="40" height="40"/> </a> <a href="https://travis-ci.org" target="_blank"> <img src="https://www.vectorlogo.zone/logos/travis-ci/travis-ci-icon.svg" alt="travisci" width="40" height="40"/> </a> <a href="https://www.gnu.org/software/bash/" target="_blank"> <img src="https://www.vectorlogo.zone/logos/gnu_bash/gnu_bash-icon.svg" alt="bash" width="40" height="40"/> </a>
-      </p>
-      </td>
-      </tr>
-      </table>
+[![Google GDE](https://img.shields.io/badge/Google%20GDE-Web%20%2F%20ML-4285F4?style=for-the-badge&logo=google&logoColor=white)](https://developers.google.com/community/experts)
+[![AWS Community Builder](https://img.shields.io/badge/AWS-Community%20Builder-FF9900?style=for-the-badge&logo=data:image/svg%2bxml;base64,PHN2ZyBmaWxsPSJ3aGl0ZSIgcm9sZT0iaW1nIiB2aWV3Qm94PSIwIDAgMjQgMjQiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PHBhdGggZD0iTTYuNzYzIDEwLjAzNmMwIC4yOTYuMDMyLjUzNS4wODguNzEuMDY0LjE3Ni4xNDQuMzY4LjI1Ni41NzYuMDQuMDYzLjA1Ni4xMjcuMDU2LjE4MyAwIC4wOC0uMDQ4LjE2LS4xNTIuMjRsLS41MDMuMzM1YS4zODMuMzgzIDAgMCAxLS4yMDguMDcyYy0uMDggMC0uMTYtLjA0LS4yMzktLjExMmEyLjQ3IDIuNDcgMCAwIDEtLjI4Ny0uMzc1IDYuMTggNi4xOCAwIDAgMS0uMjQ4LS40NzFjLS42MjIuNzM0LTEuNDA1IDEuMTAxLTIuMzQ3IDEuMTAxLS42NyAwLTEuMjA1LS4xOTEtMS41OTYtLjU3NC0uMzkxLS4zODQtLjU5LS44OTQtLjU5LTEuNTMzIDAtLjY3OC4yMzktMS4yMy43MjYtMS42NDQuNDg3LS40MTUgMS4xMzMtLjYyMyAxLjk1NS0uNjIzLjI3MiAwIC41NTEuMDI0Ljg0Ni4wNjQuMjk2LjA0LjYuMTA0LjkxOC4xNzZ2LS41ODNjMC0uNjA3LS4xMjctMS4wMy0uMzc1LTEuMjc3LS4yNTUtLjI0OC0uNjg2LS4zNjctMS4zLS4zNjctLjI4IDAtLjU2OC4wMzEtLjg2My4xMDMtLjI5NS4wNzItLjU4My4xNi0uODYyLjI3MmEyLjI4NyAyLjI4NyAwIDAgMS0uMjguMTA0LjQ4OC40ODggMCAwIDEtLjEyNy4wMjNjLS4xMTIgMC0uMTY4LS4wOC0uMTY4LS4yNDd2LS4zOTFjMC0uMTI4LjAxNi0uMjI0LjA1Ni0uMjhhLjU5Ny41OTcgMCAwIDEgLjIyNC0uMTY3Yy4yNzktLjE0NC42MTQtLjI2NCAxLjAwNS0uMzZhNC44NCA0Ljg0IDAgMCAxIDEuMjQ2LS4xNTFjLjk1IDAgMS42NDQuMjE2IDIuMDkxLjY0Ny40MzkuNDMuNjYyIDEuMDg1LjY2MiAxLjk2M3YyLjU4NnptLTMuMjQgMS4yMTRjLjI2MyAwIC41MzQtLjA0OC44MjItLjE0NC4yODctLjA5Ni41NDMtLjI3MS43NTgtLjUxLjEyOC0uMTUyLjIyNC0uMzIuMjcyLS41MTIuMDQ3LS4xOTEuMDgtLjQyMy4wOC0uNjk0di0uMzM1YTYuNjYgNi42NiAwIDAgMC0uNzM1LS4xMzYgNi4wMiA2LjAyIDAgMCAwLS43NS0uMDQ4Yy0uNTM1IDAtLjkyNi4xMDQtMS4xOS4zMi0uMjYzLjIxNS0uMzkuNTE4LS4zOS45MTcgMCAuMzc1LjA5NS42NTUuMjk1Ljg0Ni4xOTEuMi40Ny4yOTYuODM4LjI5NnptNi40MS44NjJjLS4xNDQgMC0uMjQtLjAyNC0uMzA0LS4wOC0uMDY0LS4wNDgtLjEyLS4xNi0uMTY4LS4zMTFMNy41ODYgNS41NWExLjM5OCAxLjM5OCAwIDAgMS0uMDcyLS4zMmMwLS4xMjguMDY0LS4yLjE5MS0uMmguNzgzYy4xNTEgMCAuMjU1LjAyNS4zMS4wOC4wNjUuMDQ4LjExMy4xNi4xNi4zMTJsMS4zNDIgNS4yODQgMS4yNDUtNS4yODRjLjA0LS4xNi4wODgtLjI2NC4xNTEtLjMxMmEuNTQ5LjU0OSAwIDAgMSAuMzItLjA4aC42MzhjLjE1MiAwIC4yNTYuMDI1LjMyLjA4LjA2My4wNDguMTIuMTYuMTUxLjMxMmwxLjI2MSA1LjM0OCAxLjM4MS01LjM0OGMuMDQ4LS4xNi4xMDQtLjI2NC4xNi0uMzEyYS41Mi41MiAwIDAgMSAuMzExLS4wOGguNzQzYy4xMjcgMCAuMi4wNjUuMi4yIDAgLjA0LS4wMDkuMDgtLjAxNy4xMjhhMS4xMzcgMS4xMzcgMCAwIDEtLjA1Ni4ybC0xLjkyMyA2LjE3Yy0uMDQ4LjE2LS4xMDQuMjYzLS4xNjguMzExYS41MS41MSAwIDAgMS0uMzAzLjA4aC0uNjg3Yy0uMTUxIDAtLjI1NS0uMDI0LS4zMi0uMDgtLjA2My0uMDU2LS4xMTktLjE2LS4xNS0uMzJsLTEuMjM4LTUuMTQ4LTEuMjMgNS4xNGMtLjA0LjE2LS4wODcuMjY0LS4xNS4zMi0uMDY1LjA1Ni0uMTc3LjA4LS4zMi4wOHptMTAuMjU2LjIxNWMtLjQxNSAwLS44My0uMDQ4LTEuMjI5LS4xNDMtLjM5OS0uMDk2LS43MS0uMi0uOTE4LS4zMi0uMTI4LS4wNzEtLjIxNS0uMTUxLS4yNDctLjIyM2EuNTYzLjU2MyAwIDAgMS0uMDQ4LS4yMjR2LS40MDdjMC0uMTY3LjA2NC0uMjQ3LjE4My0uMjQ3LjA0OCAwIC4wOTYuMDA4LjE0NC4wMjQuMDQ4LjAxNi4xMi4wNDguMi4wOC4yNzEuMTIuNTY2LjIxNS44NzguMjc5LjMxOS4wNjQuNjMuMDk2Ljk1LjA5Ni41MDIgMCAuODk0LS4wODggMS4xNjUtLjI2NGEuODYuODYgMCAwIDAgLjQxNS0uNzU4Ljc3Ny43NzcgMCAwIDAtLjIxNS0uNTU5Yy0uMTQ0LS4xNTEtLjQxNi0uMjg3LS44MDctLjQxNWwtMS4xNTctLjM2Yy0uNTgzLS4xODMtMS4wMTQtLjQ1NC0xLjI3Ny0uODEzYTEuOTAyIDEuOTAyIDAgMCAxLS40LTEuMTU4YzAtLjMzNS4wNzMtLjYzLjIxNi0uODg2LjE0NC0uMjU1LjMzNS0uNDc5LjU3NS0uNjU0LjI0LS4xODQuNTEtLjMyLjgzLS40MTUuMzItLjA5Ni42NTUtLjEzNiAxLjAwNi0uMTM2LjE3NSAwIC4zNTkuMDA4LjUzNS4wMzIuMTgzLjAyNC4zNS4wNTYuNTE4LjA4OC4xNi4wNC4zMTIuMDguNDU1LjEyNy4xNDQuMDQ4LjI1Ni4wOTYuMzM2LjE0NGEuNjkuNjkgMCAwIDEgLjI0LjIuNDMuNDMgMCAwIDEgLjA3MS4yNjN2LjM3NWMwIC4xNjgtLjA2NC4yNTYtLjE4NC4yNTZhLjgzLjgzIDAgMCAxLS4zMDMtLjA5NiAzLjY1MiAzLjY1MiAwIDAgMC0xLjUzMi0uMzExYy0uNDU1IDAtLjgxNS4wNzEtMS4wNjIuMjIzLS4yNDguMTUyLS4zNzUuMzgzLS4zNzUuNzEgMCAuMjI0LjA4LjQxNi4yNC41NjcuMTU5LjE1Mi40NTQuMzA0Ljg3Ny40NGwxLjEzNC4zNThjLjU3NC4xODQuOTkuNDQgMS4yMzcuNzY3LjI0Ny4zMjcuMzY3LjcwMi4zNjcgMS4xMTcgMCAuMzQzLS4wNzIuNjU1LS4yMDcuOTI2LS4xNDQuMjcyLS4zMzYuNTExLS41ODMuNzAzLS4yNDguMi0uNTQzLjM0My0uODg2LjQ0Ny0uMzYuMTExLS43MzQuMTY3LTEuMTQyLjE2N3pNMjEuNjk4IDE2LjIwN2MtMi42MjYgMS45NC02LjQ0MiAyLjk2OS05LjcyMiAyLjk2OS00LjU5OCAwLTguNzQtMS43LTExLjg3LTQuNTI2LS4yNDctLjIyMy0uMDI0LS41MjcuMjcyLS4zNTEgMy4zODQgMS45NjMgNy41NTkgMy4xNTMgMTEuODc3IDMuMTUzIDIuOTE0IDAgNi4xMTQtLjYwNyA5LjA2LTEuODUyLjQzOS0uMi44MTQuMjg3LjM4My42MDd6TTIyLjc5MiAxNC45NjFjLS4zMzYtLjQzLTIuMjItLjIwNy0zLjA3NC0uMTAzLS4yNTUuMDMyLS4yOTUtLjE5Mi0uMDYzLS4zNiAxLjUtMS4wNTMgMy45NjctLjc1IDQuMjU0LS4zOTkuMjg3LjM2LS4wOCAyLjgyNi0xLjQ4NSA0LjAwNy0uMjE1LjE4NC0uNDIzLjA4OC0uMzI3LS4xNTEuMzItLjc5IDEuMDMtMi41Ny42OTUtMi45OTR6Ii8+PC9zdmc+&logoColor=white)](https://aws.amazon.com/developer/community/community-builders/)
+[![Cloudinary MDE](https://img.shields.io/badge/Cloudinary-MDE-3448C5?style=for-the-badge&logo=cloudinary&logoColor=white)](https://cloudinary.com/developers/mdes)
+[![Oracle Groundbreaker](https://img.shields.io/badge/Oracle-Groundbreaker%20Ambassador-F80000?style=for-the-badge&logo=data:image/svg%2bxml;base64,PHN2ZyBmaWxsPSJ3aGl0ZSIgcm9sZT0iaW1nIiB2aWV3Qm94PSIwIDAgMjQgMjQiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PHBhdGggZD0iTTE2LjQxMiA0LjQxMmgtOC44MmE3LjU4OCA3LjU4OCAwIDAgMC0uMDA4IDE1LjE3Nmg4LjgyOGE3LjU4OCA3LjU4OCAwIDAgMCAwLTE1LjE3NnptLS4xOTMgMTIuNTAySDcuNzg2YTQuOTE1IDQuOTE1IDAgMCAxIDAtOS44MjhoOC40MzNhNC45MTQgNC45MTQgMCAxIDEgMCA5LjgyOHoiLz48L3N2Zz4=&logoColor=white)](https://developer.oracle.com/)
+[![Distinguished Toastmaster](https://img.shields.io/badge/Toastmasters-Distinguished-772432?style=for-the-badge)](https://www.toastmasters.org/)
+
+---
+
+### 🛠️ &nbsp; Favorite Tech
+
+![TensorFlow.js](https://img.shields.io/badge/TensorFlow.js-FF6F00?style=for-the-badge&logo=tensorflow&logoColor=white)
+![React](https://img.shields.io/badge/React-20232A?style=for-the-badge&logo=react&logoColor=61DAFB)
+![React Native](https://img.shields.io/badge/React%20Native-20232A?style=for-the-badge&logo=react&logoColor=61DAFB)
+![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
+![TypeScript](https://img.shields.io/badge/TypeScript-3178C6?style=for-the-badge&logo=typescript&logoColor=white)
+![Python](https://img.shields.io/badge/Python-3776AB?style=for-the-badge&logo=python&logoColor=white)
+![Ruby](https://img.shields.io/badge/Ruby-CC342D?style=for-the-badge&logo=ruby&logoColor=white)
+![Node.js](https://img.shields.io/badge/Node.js-339933?style=for-the-badge&logo=nodedotjs&logoColor=white)
+![AWS](https://img.shields.io/badge/AWS-232F3E?style=for-the-badge&logo=data:image/svg%2bxml;base64,PHN2ZyBmaWxsPSJ3aGl0ZSIgcm9sZT0iaW1nIiB2aWV3Qm94PSIwIDAgMjQgMjQiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PHBhdGggZD0iTTYuNzYzIDEwLjAzNmMwIC4yOTYuMDMyLjUzNS4wODguNzEuMDY0LjE3Ni4xNDQuMzY4LjI1Ni41NzYuMDQuMDYzLjA1Ni4xMjcuMDU2LjE4MyAwIC4wOC0uMDQ4LjE2LS4xNTIuMjRsLS41MDMuMzM1YS4zODMuMzgzIDAgMCAxLS4yMDguMDcyYy0uMDggMC0uMTYtLjA0LS4yMzktLjExMmEyLjQ3IDIuNDcgMCAwIDEtLjI4Ny0uMzc1IDYuMTggNi4xOCAwIDAgMS0uMjQ4LS40NzFjLS42MjIuNzM0LTEuNDA1IDEuMTAxLTIuMzQ3IDEuMTAxLS42NyAwLTEuMjA1LS4xOTEtMS41OTYtLjU3NC0uMzkxLS4zODQtLjU5LS44OTQtLjU5LTEuNTMzIDAtLjY3OC4yMzktMS4yMy43MjYtMS42NDQuNDg3LS40MTUgMS4xMzMtLjYyMyAxLjk1NS0uNjIzLjI3MiAwIC41NTEuMDI0Ljg0Ni4wNjQuMjk2LjA0LjYuMTA0LjkxOC4xNzZ2LS41ODNjMC0uNjA3LS4xMjctMS4wMy0uMzc1LTEuMjc3LS4yNTUtLjI0OC0uNjg2LS4zNjctMS4zLS4zNjctLjI4IDAtLjU2OC4wMzEtLjg2My4xMDMtLjI5NS4wNzItLjU4My4xNi0uODYyLjI3MmEyLjI4NyAyLjI4NyAwIDAgMS0uMjguMTA0LjQ4OC40ODggMCAwIDEtLjEyNy4wMjNjLS4xMTIgMC0uMTY4LS4wOC0uMTY4LS4yNDd2LS4zOTFjMC0uMTI4LjAxNi0uMjI0LjA1Ni0uMjhhLjU5Ny41OTcgMCAwIDEgLjIyNC0uMTY3Yy4yNzktLjE0NC42MTQtLjI2NCAxLjAwNS0uMzZhNC44NCA0Ljg0IDAgMCAxIDEuMjQ2LS4xNTFjLjk1IDAgMS42NDQuMjE2IDIuMDkxLjY0Ny40MzkuNDMuNjYyIDEuMDg1LjY2MiAxLjk2M3YyLjU4NnptLTMuMjQgMS4yMTRjLjI2MyAwIC41MzQtLjA0OC44MjItLjE0NC4yODctLjA5Ni41NDMtLjI3MS43NTgtLjUxLjEyOC0uMTUyLjIyNC0uMzIuMjcyLS41MTIuMDQ3LS4xOTEuMDgtLjQyMy4wOC0uNjk0di0uMzM1YTYuNjYgNi42NiAwIDAgMC0uNzM1LS4xMzYgNi4wMiA2LjAyIDAgMCAwLS43NS0uMDQ4Yy0uNTM1IDAtLjkyNi4xMDQtMS4xOS4zMi0uMjYzLjIxNS0uMzkuNTE4LS4zOS45MTcgMCAuMzc1LjA5NS42NTUuMjk1Ljg0Ni4xOTEuMi40Ny4yOTYuODM4LjI5NnptNi40MS44NjJjLS4xNDQgMC0uMjQtLjAyNC0uMzA0LS4wOC0uMDY0LS4wNDgtLjEyLS4xNi0uMTY4LS4zMTFMNy41ODYgNS41NWExLjM5OCAxLjM5OCAwIDAgMS0uMDcyLS4zMmMwLS4xMjguMDY0LS4yLjE5MS0uMmguNzgzYy4xNTEgMCAuMjU1LjAyNS4zMS4wOC4wNjUuMDQ4LjExMy4xNi4xNi4zMTJsMS4zNDIgNS4yODQgMS4yNDUtNS4yODRjLjA0LS4xNi4wODgtLjI2NC4xNTEtLjMxMmEuNTQ5LjU0OSAwIDAgMSAuMzItLjA4aC42MzhjLjE1MiAwIC4yNTYuMDI1LjMyLjA4LjA2My4wNDguMTIuMTYuMTUxLjMxMmwxLjI2MSA1LjM0OCAxLjM4MS01LjM0OGMuMDQ4LS4xNi4xMDQtLjI2NC4xNi0uMzEyYS41Mi41MiAwIDAgMSAuMzExLS4wOGguNzQzYy4xMjcgMCAuMi4wNjUuMi4yIDAgLjA0LS4wMDkuMDgtLjAxNy4xMjhhMS4xMzcgMS4xMzcgMCAwIDEtLjA1Ni4ybC0xLjkyMyA2LjE3Yy0uMDQ4LjE2LS4xMDQuMjYzLS4xNjguMzExYS41MS41MSAwIDAgMS0uMzAzLjA4aC0uNjg3Yy0uMTUxIDAtLjI1NS0uMDI0LS4zMi0uMDgtLjA2My0uMDU2LS4xMTktLjE2LS4xNS0uMzJsLTEuMjM4LTUuMTQ4LTEuMjMgNS4xNGMtLjA0LjE2LS4wODcuMjY0LS4xNS4zMi0uMDY1LjA1Ni0uMTc3LjA4LS4zMi4wOHptMTAuMjU2LjIxNWMtLjQxNSAwLS44My0uMDQ4LTEuMjI5LS4xNDMtLjM5OS0uMDk2LS43MS0uMi0uOTE4LS4zMi0uMTI4LS4wNzEtLjIxNS0uMTUxLS4yNDctLjIyM2EuNTYzLjU2MyAwIDAgMS0uMDQ4LS4yMjR2LS40MDdjMC0uMTY3LjA2NC0uMjQ3LjE4My0uMjQ3LjA0OCAwIC4wOTYuMDA4LjE0NC4wMjQuMDQ4LjAxNi4xMi4wNDguMi4wOC4yNzEuMTIuNTY2LjIxNS44NzguMjc5LjMxOS4wNjQuNjMuMDk2Ljk1LjA5Ni41MDIgMCAuODk0LS4wODggMS4xNjUtLjI2NGEuODYuODYgMCAwIDAgLjQxNS0uNzU4Ljc3Ny43NzcgMCAwIDAtLjIxNS0uNTU5Yy0uMTQ0LS4xNTEtLjQxNi0uMjg3LS44MDctLjQxNWwtMS4xNTctLjM2Yy0uNTgzLS4xODMtMS4wMTQtLjQ1NC0xLjI3Ny0uODEzYTEuOTAyIDEuOTAyIDAgMCAxLS40LTEuMTU4YzAtLjMzNS4wNzMtLjYzLjIxNi0uODg2LjE0NC0uMjU1LjMzNS0uNDc5LjU3NS0uNjU0LjI0LS4xODQuNTEtLjMyLjgzLS40MTUuMzItLjA5Ni42NTUtLjEzNiAxLjAwNi0uMTM2LjE3NSAwIC4zNTkuMDA4LjUzNS4wMzIuMTgzLjAyNC4zNS4wNTYuNTE4LjA4OC4xNi4wNC4zMTIuMDguNDU1LjEyNy4xNDQuMDQ4LjI1Ni4wOTYuMzM2LjE0NGEuNjkuNjkgMCAwIDEgLjI0LjIuNDMuNDMgMCAwIDEgLjA3MS4yNjN2LjM3NWMwIC4xNjgtLjA2NC4yNTYtLjE4NC4yNTZhLjgzLjgzIDAgMCAxLS4zMDMtLjA5NiAzLjY1MiAzLjY1MiAwIDAgMC0xLjUzMi0uMzExYy0uNDU1IDAtLjgxNS4wNzEtMS4wNjIuMjIzLS4yNDguMTUyLS4zNzUuMzgzLS4zNzUuNzEgMCAuMjI0LjA4LjQxNi4yNC41NjcuMTU5LjE1Mi40NTQuMzA0Ljg3Ny40NGwxLjEzNC4zNThjLjU3NC4xODQuOTkuNDQgMS4yMzcuNzY3LjI0Ny4zMjcuMzY3LjcwMi4zNjcgMS4xMTcgMCAuMzQzLS4wNzIuNjU1LS4yMDcuOTI2LS4xNDQuMjcyLS4zMzYuNTExLS41ODMuNzAzLS4yNDguMi0uNTQzLjM0My0uODg2LjQ0Ny0uMzYuMTExLS43MzQuMTY3LTEuMTQyLjE2N3pNMjEuNjk4IDE2LjIwN2MtMi42MjYgMS45NC02LjQ0MiAyLjk2OS05LjcyMiAyLjk2OS00LjU5OCAwLTguNzQtMS43LTExLjg3LTQuNTI2LS4yNDctLjIyMy0uMDI0LS41MjcuMjcyLS4zNTEgMy4zODQgMS45NjMgNy41NTkgMy4xNTMgMTEuODc3IDMuMTUzIDIuOTE0IDAgNi4xMTQtLjYwNyA5LjA2LTEuODUyLjQzOS0uMi44MTQuMjg3LjM4My42MDd6TTIyLjc5MiAxNC45NjFjLS4zMzYtLjQzLTIuMjItLjIwNy0zLjA3NC0uMTAzLS4yNTUuMDMyLS4yOTUtLjE5Mi0uMDYzLS4zNiAxLjUtMS4wNTMgMy45NjctLjc1IDQuMjU0LS4zOTkuMjg3LjM2LS4wOCAyLjgyNi0xLjQ4NSA0LjAwNy0uMjE1LjE4NC0uNDIzLjA4OC0uMzI3LS4xNTEuMzItLjc5IDEuMDMtMi41Ny42OTUtMi45OTR6Ii8+PC9zdmc+&logoColor=white)
+![AWS Amplify](https://img.shields.io/badge/AWS%20Amplify-FF9900?style=for-the-badge&logo=data:image/svg%2bxml;base64,PHN2ZyBmaWxsPSJ3aGl0ZSIgcm9sZT0iaW1nIiB2aWV3Qm94PSIwIDAgMjQgMjQiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PHBhdGggZD0iTTUuMjIzIDE3LjkwNWg2Ljc2bDEuNzMxIDMuMDQ3SDBsNC44MTUtOC4zNDQgMi4wMTgtMy40OTQgMS43MzMgMy4wMDJ6bTIuNTItMTAuMzcxTDkuNDA4IDQuNjVsOS40MTUgMTYuMzAxaC0zLjMzNHptMi41OS00LjQ4NmgzLjMzTDI0IDIwLjk1MmgtMy4zMzR6Ii8+PC9zdmc+&logoColor=white)
+![Google Cloud](https://img.shields.io/badge/GCP-4285F4?style=for-the-badge&logo=googlecloud&logoColor=white)
+![Android](https://img.shields.io/badge/Android-3DDC84?style=for-the-badge&logo=android&logoColor=white)
+![Arduino](https://img.shields.io/badge/Arduino-00979D?style=for-the-badge&logo=arduino&logoColor=white)
+![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
+![CSS3](https://img.shields.io/badge/CSS3-1572B6?style=for-the-badge&logo=css&logoColor=white)
+![Jest](https://img.shields.io/badge/Jest-C21325?style=for-the-badge&logo=jest&logoColor=white)
+![Git](https://img.shields.io/badge/Git-F05032?style=for-the-badge&logo=git&logoColor=white)
+![Linux](https://img.shields.io/badge/Linux-FCC624?style=for-the-badge&logo=linux&logoColor=black)
+![Bash](https://img.shields.io/badge/Bash-4EAA25?style=for-the-badge&logo=gnubash&logoColor=white)
+![Postman](https://img.shields.io/badge/Postman-FF6C37?style=for-the-badge&logo=postman&logoColor=white)
+![Photoshop](https://img.shields.io/badge/Photoshop-31A8FF?style=for-the-badge&logo=data:image/svg%2bxml;base64,PHN2ZyBmaWxsPSJ3aGl0ZSIgcm9sZT0iaW1nIiB2aWV3Qm94PSIwIDAgMjQgMjQiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PHBhdGggZD0iTTkuODUgOC40MmMtLjM3LS4xNS0uNzctLjIxLTEuMTgtLjItLjI2IDAtLjQ5IDAtLjY4LjAxLS4yLS4wMS0uMzQgMC0uNDEuMDF2My4zNmMuMTQuMDEuMjcuMDIuMzkuMDJoLjUzYy4zOSAwIC43OC0uMDYgMS4xNS0uMTguMzItLjA5LjYtLjI4LjgyLS41My4yMS0uMjUuMzEtLjU5LjMxLTEuMDMuMDEtLjMxLS4wNy0uNjItLjIzLS44OS0uMTctLjI2LS40MS0uNDYtLjctLjU3ek0xOS43NS4zSDQuMjVDMS45LjMgMCAyLjIgMCA0LjU1djE0Ljg5OWMwIDIuMzUgMS45IDQuMjUgNC4yNSA0LjI1aDE1LjVjMi4zNSAwIDQuMjUtMS45IDQuMjUtNC4yNVY0LjU1QzI0IDIuMiAyMi4xLjMgMTkuNzUuM3ptLTcuMzkxIDExLjY1Yy0uMzk5LjU2LS45NTkuOTgtMS42MDkgMS4yMi0uNjguMjUtMS40My4zNC0yLjI1LjM0LS4yNCAwLS40IDAtLjUtLjAxcy0uMjQtLjAxLS40My0uMDF2My4yMDljLjAxLjA3LS4wNC4xMzEtLjExLjE0MUg1LjUyYy0uMDggMC0uMTItLjA0MS0uMTItLjEzMVY2LjQyYzAtLjA3LjAzLS4xMS4xLS4xMS4xNyAwIC4zMyAwIC41Ni0uMDEuMjQtLjAxLjQ5LS4wMS43Ni0uMDJzLjU2LS4wMS44Ny0uMDJjLjMxLS4wMS42MS0uMDEuOTEtLjAxLjgyIDAgMS41LjEgMi4wNi4zMS41LjE3Ljk2LjQ1IDEuMzQuODIuMzIuMzIuNTcuNzEuNzMgMS4xNC4xNDkuNDIuMjI5Ljg1LjIyOSAxLjMuMDAxLjg2LS4xOTkgMS41Ny0uNiAyLjEzem03LjA5MSAzLjg5Yy0uMjguNC0uNjcxLjcwOS0xLjEyLjg5MS0uNDkuMjA5LTEuMDkuMzE4LTEuODExLjMxOC0uNDU5IDAtLjkxLS4wMzktMS4zNTktLjEyOS0uMzUtLjA2MS0uNy0uMTctMS4wMi0uMzItLjA3LS4wMzktLjEyMS0uMTA5LS4xMTEtLjE4OXYtMS43NGMwLS4wMjkuMDExLS4wNy4wNDEtLjA5LjAyOS0uMDIuMDYtLjAxLjA5LjAxLjM5LjIzLjguMzkxIDEuMjQuNDkuMzc5LjEuNzc5LjE1IDEuMTguMTUuMzggMCAuNjUtLjA1MS44My0uMTQxLjE2LS4wNy4yNy0uMjQuMjctLjQyIDAtLjE0MS0uMDgtLjI3LS4yNC0uNC0uMTYtLjEyOS0uNDg5LS4yNzktLjk3OS0uNDcxLS41MS0uMTgtLjk3OS0uNDItMS40Mi0uNzE5LS4zMS0uMjIxLS41NjktLjUxLS43NjEtLjg1LS4xNTktLjMyLS4yMzktLjY3LS4yMjktMS4wMjEgMC0uNDMuMTItLjg0LjM0MS0xLjIxLjI1LS40LjYxOS0uNzIgMS4wNDktLjkyLjQ2OS0uMjM5IDEuMDU5LS4zNDkgMS43NjktLjM0OS40MSAwIC44My4wMyAxLjI0LjA5LjMuMDQuNTkuMTIuODYuMjMuMDM5LjAxLjA4LjA1LjEuMDkuMDEuMDQuMDIuMDguMDIuMTJ2MS42M2MwIC4wNC0uMDIuMDgtLjA1LjEtLjA5LjAyLS4xNC4wMi0uMTggMC0uMy0uMTYtLjYyLS4yNy0uOTYtLjM0LS4zNy0uMDgtLjc0LS4xMy0xLjEyLS4xMy0uMi0uMDEtLjQxLjAyLS42MDEuMDctLjEyOS4wMy0uMjQuMS0uMzEuMi0uMDUuMDgtLjA4LjE4LS4wOC4yN3MuMDQuMTguMTAxLjI2Yy4wOS4xMS4yMDkuMi4zNC4yNy4yMjkuMTIuNDcuMjMuNzA5LjMzLjU0MS4xOCAxLjA2MS40MyAxLjU0MS43My4zMy4yMDkuNi40OS43ODkuODMuMTYuMzE4LjI0LjY3LjIzIDEuMDI5LjAxMS40NzEtLjEyOS45NC0uMzg5IDEuMzMxeiIvPjwvc3ZnPg==&logoColor=white)
+
+---
 
 ### 📜 &nbsp; My most recent blog posts
 <!-- BLOG-POST-LIST:START -->
-- [Chain React Conf vs COVID — 2022](https://shift.infinite.red/chain-react-conf-vs-covid-2022-919724bf5aae?source=rss-6ca0fe37eac1------2)
+- [Chain React Conf vs COVID — 2022](https://shift.infinite.red/chain-react-conf-vs-covid-2022-919724bf5aae?source=rss-6ca0fe37eac1------2)
 - [Gifting Cryptocurrency to Kids](https://shift.infinite.red/gifting-cryptocurrency-to-kids-c9c5a4644f31?source=rss-6ca0fe37eac1------2)
 - [The Ultimate Productivity Hack](https://shift.infinite.red/the-ultimate-productivity-hack-6eb2cf921d0e?source=rss-6ca0fe37eac1------2)
-- [Magic Arrow Puzzle — 3D Geometry](https://shift.infinite.red/magic-arrow-puzzle-3d-geometry-50fa2844d65?source=rss-6ca0fe37eac1------2)
+- [Magic Arrow Puzzle — 3D Geometry](https://shift.infinite.red/magic-arrow-puzzle-3d-geometry-50fa2844d65?source=rss-6ca0fe37eac1------2)
 - [[From our friends] Dicify AI](https://blog.codiga.io/from-our-friends-dicify-ai-8c58a4016586?source=rss-6ca0fe37eac1------2)
 <!-- BLOG-POST-LIST:END -->
 
+---
 
+### 📊 &nbsp; GitHub Stats
 
-<p><img align="left" src="https://github-readme-stats.vercel.app/api/top-langs/?username=gantman&layout=compact&hide=html" alt="gantman" /></p>
+<a href="https://github.com/gantman">
+  <img height="170" src="https://github-readme-streak-stats.herokuapp.com/?user=gantman&theme=tokyonight&hide_border=true" alt="Gant's GitHub streak" />
+</a>
 
-<p>&nbsp;<img align="center" style="max-width: 50%" width="50%" src="https://github-readme-stats.vercel.app/api?username=gantman&show_icons=true" alt="gantman" /></p>
+<a href="https://github.com/gantman">
+  <img src="https://github-profile-trophy.vercel.app/?username=gantman&theme=tokyonight&no-frame=true&margin-w=8&row=1&column=7" alt="Gant's GitHub trophies" />
+</a>
 
-<p align="center">
-<a href="https://twitter.com/https://twitter.com/gantlaborde" target="blank"><img align="center" src="https://cdn.jsdelivr.net/npm/simple-icons@3.0.1/icons/twitter.svg" alt="https://twitter.com/gantlaborde" height="30" width="30" /></a>
-<a href="https://linkedin.com/in/https://www.linkedin.com/in/gant-laborde/" target="blank"><img align="center" src="https://cdn.jsdelivr.net/npm/simple-icons@3.0.1/icons/linkedin.svg" alt="https://www.linkedin.com/in/gant-laborde/" height="30" width="30" /></a>
-<a href="https://stackoverflow.com/users/1250389" target="blank"><img align="center" src="https://cdn.jsdelivr.net/npm/simple-icons@3.0.1/icons/stackoverflow.svg" alt="1250389" height="30" width="30" /></a>
-<a href="https://medium.com/@gantlaborde" target="blank"><img align="center" src="https://cdn.jsdelivr.net/npm/simple-icons@3.0.1/icons/medium.svg" alt="@gantlaborde" height="30" width="30" /></a>
-</p>
+---
+
+### 🌐 &nbsp; Connect
+
+[![Twitter](https://img.shields.io/badge/Twitter-000000?style=for-the-badge&logo=x&logoColor=white)](https://twitter.com/GantLaborde)
+[![LinkedIn](https://img.shields.io/badge/LinkedIn-0A66C2?style=for-the-badge&logo=data:image/svg%2bxml;base64,PHN2ZyBmaWxsPSJ3aGl0ZSIgcm9sZT0iaW1nIiB2aWV3Qm94PSIwIDAgMjQgMjQiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PHBhdGggZD0iTTIwLjQ0NyAyMC40NTJoLTMuNTU0di01LjU2OWMwLTEuMzI4LS4wMjctMy4wMzctMS44NTItMy4wMzctMS44NTMgMC0yLjEzNiAxLjQ0NS0yLjEzNiAyLjkzOXY1LjY2N0g5LjM1MVY5aDMuNDE0djEuNTYxaC4wNDZjLjQ3Ny0uOSAxLjYzNy0xLjg1IDMuMzctMS44NSAzLjYwMSAwIDQuMjY3IDIuMzcgNC4yNjcgNS40NTV2Ni4yODZ6TTUuMzM3IDcuNDMzYy0xLjE0NCAwLTIuMDYzLS45MjYtMi4wNjMtMi4wNjUgMC0xLjEzOC45Mi0yLjA2MyAyLjA2My0yLjA2MyAxLjE0IDAgMi4wNjQuOTI1IDIuMDY0IDIuMDYzIDAgMS4xMzktLjkyNSAyLjA2NS0yLjA2NCAyLjA2NXptMS43ODIgMTMuMDE5SDMuNTU1VjloMy41NjR2MTEuNDUyek0yMi4yMjUgMEgxLjc3MUMuNzkyIDAgMCAuNzc0IDAgMS43Mjl2MjAuNTQyQzAgMjMuMjI3Ljc5MiAyNCAxLjc3MSAyNGgyMC40NTFDMjMuMiAyNCAyNCAyMy4yMjcgMjQgMjIuMjcxVjEuNzI5QzI0IC43NzQgMjMuMiAwIDIyLjIyMiAwaC4wMDN6Ii8+PC9zdmc+&logoColor=white)](https://www.linkedin.com/in/gant-laborde/)
+[![Medium](https://img.shields.io/badge/Medium-12100E?style=for-the-badge&logo=medium&logoColor=white)](https://medium.com/@gantlaborde)
+[![Stack Overflow](https://img.shields.io/badge/Stack%20Overflow-F58025?style=for-the-badge&logo=stackoverflow&logoColor=white)](https://stackoverflow.com/users/1250389)
+[![Website](https://img.shields.io/badge/Website-1f6feb?style=for-the-badge&logo=safari&logoColor=white)](https://gantlaborde.com/)


### PR DESCRIPTION
## Summary

The profile README was rendering poorly on GitHub dark mode (icons stacked vertically in a cramped table column, social-link SVGs invisible against the dark background, broken Amplify image), and the blog-post auto-update workflow had been silently failing since Jan 2022. This PR fixes both.

### README changes

- **Layout** — drop the nested `<table>` that was forcing tech icons into a narrow column. Use shields.io brand-colored badges that flow naturally and render the same in light/dark mode.
- **Dark-mode social icons** — the previous `simple-icons@3.0.1` SVGs had no `fill` attribute, so they defaulted to black and went invisible on GitHub dark. Replaced with colored shields.io badges.
- **shields.io logo gaps** — shields.io silently drops several brand logos (linkedin, oracle, amazonaws, awsamplify, adobephotoshop, toastmasters, css3). For the ones that matter, the `logo=` parameter now carries a base64-encoded simple-icons SVG (`fill="white"` injected) so each badge displays its real brand mark. CSS3 just uses `logo=css` which works.
- **Bug fixes** — repaired the duplicated paths in the Twitter (`https://twitter.com/https://twitter.com/...`) and LinkedIn URLs.
- **Stats card** — `github-readme-stats.vercel.app` is currently returning `DEPLOYMENT_PAUSED` (Vercel hobby quota) and has been intermittent. Switched to `github-readme-streak-stats.herokuapp.com` (streak) + `github-profile-trophy.vercel.app` (trophies), both currently 200 OK.

### Workflow changes

`.github/workflows/blog-post-workflow.yml`:

- `actions/checkout@v2` → `@v4` (v2 was deprecated, a probable cause of the silent failures).
- `gautamkrishnar/blog-post-workflow@master` → `@v1` (pinned tag).
- Added `permissions: contents: write` so the action can push README updates under default `GITHUB_TOKEN` scopes.
- Added `https://shift.infinite.red/feed` alongside the personal Medium feed so Red Shift publication posts surface.
- Set `max_post_count: 6`.

## Test plan

- [ ] Verify the rendered README looks good in both **light and dark** mode after merge — every badge should show both its brand color and its icon (Toastmasters is intentionally text-only since neither shields.io nor simple-icons has that logo).
- [ ] Open **Actions → Latest blog post workflow** and click **Run workflow** once after merge. GitHub auto-disables scheduled workflows on repos with no commits in 60 days, so the merge alone may not be enough — a manual run kicks the schedule back on and confirms the action's auth/feed settings work.
- [ ] Confirm the next scheduled run rewrites between the `<!-- BLOG-POST-LIST:START -->` / `:END -->` markers with current Medium posts (most recent post should be _Pushy Notification_, Aug 2025, or _React Native vs Lynx JS_, Mar 2025).
- [ ] Confirm GitHub stats widgets (streak + trophies) load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)